### PR TITLE
test: add security and validation tests

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -19,3 +19,21 @@ def test_validate_input_files(tmp_path: Path) -> None:
 
     with pytest.raises(FileNotFoundError):
         validate_input_files(t, tmp_path / "missing.docx")
+
+
+def test_validate_input_files_rejects_non_docx(tmp_path: Path) -> None:
+    """Non-.docx inputs should raise ValueError."""
+    t = tmp_path / "t.txt"
+    w = tmp_path / "w.docx"
+    t.write_bytes(b"\0")
+    w.write_bytes(b"\0")
+    with pytest.raises(ValueError):
+        validate_input_files(t, w)
+
+
+def test_validate_input_files_rejects_large_file(tmp_path: Path) -> None:
+    """Files exceeding the size limit should be rejected."""
+    big = tmp_path / "big.docx"
+    big.write_bytes(b"0" * (11 * 1024 * 1024))
+    with pytest.raises(ValueError):
+        validate_input_files(big, big)

--- a/tests/test_processing_extra.py
+++ b/tests/test_processing_extra.py
@@ -70,6 +70,15 @@ def test_extract_fields_table() -> None:
     assert fields["{Applicant name}"] == "Foo"
 
 
+def test_extract_fields_multiline_answer() -> None:
+    doc = Document()
+    doc.add_paragraph("Question 15:")
+    doc.add_paragraph("Line1")
+    doc.add_paragraph("Line2")
+    fields = processing.extract_fields(doc, {"Question 15:": "{Q15}"})
+    assert fields["{Q15}"] == "Line1\nLine2"
+
+
 def test_replace_placeholders_full(monkeypatch: Any) -> None:
     doc = Document()
     doc.add_paragraph("{x}")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,23 @@
+"""Tests for security utilities."""
+
+from pathlib import Path
+
+import pytest
+
+from scdocbuilder.security import reject_macros
+
+
+def test_reject_macros_docm_extension(tmp_path: Path) -> None:
+    """Macro-enabled .docm files should be rejected."""
+    path = tmp_path / "file.docm"
+    path.write_bytes(b"\0")
+    with pytest.raises(ValueError):
+        reject_macros(path)
+
+
+def test_reject_macros_signature(tmp_path: Path) -> None:
+    """DOCX containing macro signatures should be rejected."""
+    path = tmp_path / "file.docx"
+    path.write_bytes(b"vbaProject")
+    with pytest.raises(ValueError):
+        reject_macros(path)


### PR DESCRIPTION
## Summary
- ensure `validate_input_files` rejects non-DOCX and oversize files
- cover macro rejection safety checks
- prepare for multiline answer extraction in worksheets

## Testing
- `ruff check tests/test_io.py tests/test_security.py tests/test_processing_extra.py`
- `black tests/test_io.py tests/test_security.py tests/test_processing_extra.py`
- `mypy src/scdocbuilder`
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68910cff4b2883329e87347b99ee1d18