### PR TITLE
test: add determinism and tiptap checks

### DIFF
--- a/tests/e2e/features/drag_drop_files.feature
+++ b/tests/e2e/features/drag_drop_files.feature
@@ -1,0 +1,5 @@
+Feature: Web drag and drop upload
+  Scenario: User uploads files via drag-and-drop and receives download link
+    Given the user drags and drops a valid template and worksheet onto the upload area
+    When the files are processed
+    Then a progress bar is shown and the download link appears within five seconds

--- a/tests/e2e/features/keyboard_navigation.feature
+++ b/tests/e2e/features/keyboard_navigation.feature
@@ -1,0 +1,5 @@
+Feature: Web keyboard navigation
+  Scenario: User navigates upload, preview, and download controls via keyboard
+    Given the web interface is open
+    When the user presses the Tab key repeatedly
+    Then focus reaches the upload input, preview button, and download link in order

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,0 +1,46 @@
+import typing
+from pathlib import Path
+from hashlib import sha256
+
+import pytest
+
+if typing.TYPE_CHECKING:
+    from docx import Document
+else:
+    pytest.importorskip("docx")
+    from docx import Document
+
+from scdocbuilder import fill_template
+
+
+def _make_docs(tmp_path: Path) -> tuple[Path, Path]:
+    template = tmp_path / "t.docx"
+    tdoc = Document()
+    tdoc.add_paragraph("{Applicant name} {Airplane model}")
+    tdoc.save(str(template))
+
+    worksheet = tmp_path / "w.docx"
+    wdoc = Document()
+    wdoc.add_paragraph("Applicant name: Foo")
+    wdoc.add_paragraph("Airplane model: Bar")
+    wdoc.add_paragraph("Question 15:")
+    wdoc.add_paragraph("Ans15")
+    wdoc.add_paragraph("Question 16:")
+    wdoc.add_paragraph("Ans16")
+    wdoc.add_paragraph("Question 17:")
+    wdoc.add_paragraph("Ans17")
+    wdoc.save(str(worksheet))
+    return template, worksheet
+
+
+def test_fill_template_repeatable(tmp_path: Path) -> None:
+    template, worksheet = _make_docs(tmp_path)
+    out1 = tmp_path / "out1.docx"
+    out2 = tmp_path / "out2.docx"
+
+    fill_template(template, worksheet, out1)
+    fill_template(template, worksheet, out2)
+
+    h1 = sha256(out1.read_bytes()).hexdigest()
+    h2 = sha256(out2.read_bytes()).hexdigest()
+    assert h1 == h2


### PR DESCRIPTION
## Summary
- ensure exported HTML uses only TipTap-compatible tags
- add repeatability test verifying consistent SHA-256 outputs
- document web drag-and-drop and keyboard navigation scenarios

## Testing
- `ruff check tests/test_html_export.py tests/test_determinism.py && ruff format tests/test_html_export.py tests/test_determinism.py`


------
https://chatgpt.com/codex/tasks/task_e_6893875b8a648332be13d09093a3d281