### PR TITLE
Add packaging console script test

### DIFF
--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import tomllib
+
+
+def test_console_script_entrypoint() -> None:
+    """pyproject.toml should expose `scdocbuilder` console script."""
+    data = tomllib.loads(Path("pyproject.toml").read_text())
+    scripts = data.get("tool", {}).get("poetry", {}).get("scripts", {})
+    assert scripts.get("scdocbuilder") == "scdocbuilder.cli:main"


### PR DESCRIPTION
## Summary
- add test asserting pyproject exposes `scdocbuilder` console script entrypoint

## Testing
- `pre-commit run --files tests/test_packaging.py` *(fails: pre-commit command not found)*
- `pip install pre-commit` *(fails: 403 while connecting to proxy)*
- `git commit -m "test: verify console script entrypoint"`

------
https://chatgpt.com/codex/tasks/task_e_689392a813408332acb1a844d946e72e