### PR TITLE
docs: refresh guides and API reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+- CLI with template and worksheet flags
+- Batch processing and `--dry-run` support
+- FastAPI `/generate` and `/health` endpoints
+- HTML export for TipTap editors
+- Macro detection and cleanup helpers

--- a/README.md
+++ b/README.md
@@ -1,150 +1,37 @@
-# FAA Special Conditions Document Builder
-
-This project automates replacing placeholders in FAA Special Conditions notice templates using data from worksheet documents.
-
-## Repository layout
-
-```
-├── src/                # library code
-│   └── scdocbuilder/
-├── tests/              # unit and property tests
-├── docs/               # documentation for MkDocs
-├── scripts/            # helper scripts used in CI
-├── .github/workflows/  # CI configuration
-└── .dev/               # planning documents and ADRs (not packaged)
-```
-
-The `src/` layout keeps import paths stable when running tests and building wheels.
-
----
-
 # SCDocBuilder
 
-Build FAA Special‑Conditions documents—CLI, FastAPI, and template engine in one repo.
+Fill FAA Special Conditions templates with worksheet answers.
 
-**SCDocBuilder** takes a worksheet of parameters (title, applicability, regulatory basis, etc.) and produces a legally formatted Special‑Conditions Word document—or HTML for TipTap—ready for FAA publication. The repository bundles:
+## What
 
-* a **CLI** (`scdocbuilder`) for local workflows
-* a **FastAPI** backend (optional) for web integrations
-* unit‑tested template logic so every output meets AIR‑646 style
+SCDocBuilder reads your worksheet and writes a polished Special Conditions
+notice. It handles table fields, conditional blocks and multiline responses.
 
----
+## Why
 
-## ✨ Quick install (recommended)
+You avoid manual editing and stay consistent with AIR-646 style in seconds.
 
-We keep the tooling consistent with the `*ScriptCLI` family: **pipx** for global shims, **uv** for super‑fast Python/venv work, and **Poetry ≥ 1.8** for lock‑file sync.
+## How
 
-```bash
-# 0 One‑time per machine ────────────────────────────────────────────────
-python3 -m pip install --user pipx
-python3 -m pipx ensurepath                         # restart shell if PATH changed
+* CLI: `python -m scdocbuilder`
+* FastAPI: `uvicorn scdocbuilder.api:app`
+* Library: call functions in [`docs/api/python.md`](docs/api/python.md)
 
-pipx install uv                                    # https://github.com/astral-sh/uv
-pipx install poetry                                # https://python-poetry.org/
-
-# 1 Per project ────────────────────────────────────────────────────────
-git clone https://github.com/eputnam77/SCDocBuilder.git
-cd SCDocBuilder
-
-# 2 Create & activate .venv (CPython 3.13) --------------------------------
-uv python install 3.13.0                           # downloads if missing
-uv venv --python 3.13.0                            # writes .venv/ by default
-source .venv/bin/activate                          # Windows: .venv\Scripts\activate
-
-# 3 Sync deps at uv speed ------------------------------------------------
-poetry config installer.executable uv              # once per machine
-poetry sync --with dev                             # mirrors poetry.lock + dev deps
-
-# 4 Developer extras ----------------------------------------------------
-pre-commit install                                 # Git hooks
-```
-
----
-
-## Alternative installs
-
-| Scenario                 | Command                                                                   |
-| ------------------------ | ------------------------------------------------------------------------- |
-| **PyPI (when released)** | `pip install scdocbuilder`                                                |
-| **Direct Git source**    | `python -m pip install git+https://github.com/eputnam77/SCDocBuilder.git` |
-
-After a package‑based install you can locate the source directory with:
-
-```bash
-cd "$(python - <<'PY'
-import importlib, pathlib
-print(pathlib.Path(importlib.import_module("scdocbuilder").__file__).parent.parent)
-PY
-)"
-```
-
----
-
-## 🐍 Virtual‑env fallback (no uv)
-
-```bash
-python -m venv .venv
-# macOS / Linux
-source .venv/bin/activate
-# Windows
-.venv\Scripts\activate
-
-python -m pip install --upgrade pip
-pip install poetry
-poetry install --with dev --sync          # --sync flag still works but is deprecated
-pre-commit install
-```
-
----
-
-## Usage examples
-
-```bash
-# Display the CLI help
-python -m scdocbuilder --help
-
-# Generate DOCX from a worksheet
-scdocbuilder build worksheet.xlsx --format docx --output sc.docx
-
-# Dry‑run HTML for TipTap editing
-scdocbuilder build worksheet.xlsx --format html --dry-run
-```
-
----
-
-## Running the API (optional)
-
-```bash
-uvicorn scdocbuilder.api:app --reload --port 8000
-# Browse interactive docs at http://localhost:8000/docs
-```
-
----
-
-### About the requirement files
-
-`requirements.txt` & `requirements‑dev.txt` exist only for legacy tooling. **`poetry sync`** (or **`pip install -e ".[dev]"`**) remains the authoritative way to stay in lock‑step with **pyproject.toml**.
-
----
+See [`docs/scenarios.md`](docs/scenarios.md) for step-by-step tasks.
 
 ## Quick start
 
-Generate a document from the command line:
-
 ```bash
-python -m scdocbuilder \
-  --template template.docx \
-  --worksheet worksheet.docx \
-  --schema schema.json
+python -m pip install scdocbuilder
+python -m scdocbuilder --template template.docx --worksheet worksheet.docx
 ```
 
 ## Contributing
 
-1. Install dev dependencies with `poetry install --with dev`.
-2. Run `pre-commit` before committing to lint and format code.
-3. Ensure tests pass with `pytest -q`.
+* `poetry install --with dev`
+* `pre-commit run --files <changed-files>`
+* `pytest -q`
 
 ## License
 
-This project is licensed under the **GNU General Public License v3.0**. See
-the [LICENSE](LICENSE) file for full terms.
+GNU General Public License v3.0. See [LICENSE](LICENSE).

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -1,0 +1,115 @@
+# Python API
+
+Use these helpers when you embed SCDocBuilder in your own tools.
+
+## fill_template
+
+```python
+fill_template(template_path, worksheet_path, output_path=None, schema=None)
+```
+
+Fill a template with answers from a worksheet.
+
+* **template_path** – path to the template DOCX.
+* **worksheet_path** – path to the worksheet DOCX.
+* **output_path** – optional output location; default creates a
+  timestamped file.
+* **schema** – optional placeholder mapping.
+
+Returns the path to the generated DOCX.
+
+## extract_fields
+
+```python
+extract_fields(doc, field_mappings=None)
+```
+
+Pull placeholder values from a worksheet document.
+
+## replace_placeholders
+
+```python
+replace_placeholders(doc, values)
+```
+
+Swap placeholders in a document for supplied values.
+
+## apply_conditionals
+
+```python
+apply_conditionals(doc, answers)
+```
+
+Remove blocks that do not match the chosen option.
+
+## load_placeholder_schema
+
+```python
+load_placeholder_schema(path)
+```
+
+Load placeholder mappings from JSON or YAML.
+
+## validate_input_files
+
+```python
+validate_input_files(template, worksheet)
+```
+
+Check that template and worksheet exist, are DOCX and under 10MB.
+
+## load_document
+
+```python
+load_document(path)
+```
+
+Open a Word document using `python-docx`.
+
+## save_document
+
+```python
+save_document(doc, path)
+```
+
+Write a document to disk.
+
+## validate_mandatory_fields
+
+```python
+validate_mandatory_fields(doc)
+```
+
+Raise `ValueError` if required fields or questions are missing.
+
+## export_html
+
+```python
+export_html(doc)
+```
+
+Convert a document to sanitized HTML.
+
+## reject_macros
+
+```python
+reject_macros(path)
+```
+
+Raise `ValueError` when macros are detected.
+
+## cleanup_uploads
+
+```python
+cleanup_uploads(*paths)
+```
+
+Delete uploaded files after processing.
+
+## benchmark_processing
+
+```python
+benchmark_processing(template, worksheet)
+```
+
+Return the time in seconds needed to load both files.

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -1,0 +1,174 @@
+# Scenarios
+
+Real tasks that show how SCDocBuilder fits your workflow.
+
+## Generate a document from the CLI
+
+**Use case**
+
+You want a filled Special Conditions notice from a worksheet.
+
+**Before you begin**
+
+* Install the package.
+* Prepare `template.docx` and `worksheet.docx`.
+
+**Steps**
+
+1. Run:
+
+   ```bash
+   python -m scdocbuilder \
+     --template template.docx \
+     --worksheet worksheet.docx
+   ```
+
+**Result**
+
+A new DOCX appears in your working folder.
+
+## Preview changes without saving
+
+**Use case**
+
+You want to see the placeholder diff before writing a file.
+
+**Before you begin**
+
+* Follow the previous scenario.
+
+**Steps**
+
+1. Run:
+
+   ```bash
+   python -m scdocbuilder \
+     --template template.docx \
+     --worksheet worksheet.docx \
+     --dry-run
+   ```
+
+**Result**
+
+JSON diff prints to the terminal.
+
+## Export sanitized HTML
+
+**Use case**
+
+You need HTML for a TipTap editor.
+
+**Before you begin**
+
+* Prepare template and worksheet files.
+
+**Steps**
+
+1. Run:
+
+   ```bash
+   python -m scdocbuilder \
+     --template template.docx \
+     --worksheet worksheet.docx \
+     --html-out result.html
+   ```
+
+**Result**
+
+`result.html` contains cleaned HTML ready for editors.
+
+## Generate through the API
+
+**Use case**
+
+You want to automate document creation from another service.
+
+**Before you begin**
+
+* `uvicorn scdocbuilder.api:app --port 8000` is running.
+
+**Steps**
+
+1. Run:
+
+   ```bash
+   curl -F template=@template.docx \
+        -F worksheet=@worksheet.docx \
+        http://localhost:8000/generate \
+        -o sc.docx
+   ```
+
+**Result**
+
+`sc.docx` downloads with all placeholders replaced.
+
+## Request HTML from the API
+
+**Use case**
+
+You need sanitized HTML instead of a DOCX file.
+
+**Before you begin**
+
+* API server is running.
+
+**Steps**
+
+1. Run:
+
+   ```bash
+   curl -F template=@template.docx \
+        -F worksheet=@worksheet.docx \
+        "http://localhost:8000/generate?html=true" \
+        > sc.html
+   ```
+
+**Result**
+
+`sc.html` contains sanitized markup.
+
+## Check service health
+
+**Use case**
+
+You want to confirm the API is live.
+
+**Before you begin**
+
+* API server is running.
+
+**Steps**
+
+1. Run:
+
+   ```bash
+   curl http://localhost:8000/health
+   ```
+
+**Result**
+
+`{"status": "ok"}`
+
+## Macro rejection
+
+**Use case**
+
+You need assurance that uploaded files do not carry macros.
+
+**Before you begin**
+
+* Have a `.docm` file.
+
+**Steps**
+
+1. Run:
+
+   ```bash
+   curl -F template=@file.docm \
+        -F worksheet=@worksheet.docx \
+        http://localhost:8000/generate
+   ```
+
+**Result**
+
+The API responds with an error and no file is kept on disk.

--- a/src/scdocbuilder/__init__.py
+++ b/src/scdocbuilder/__init__.py
@@ -39,8 +39,19 @@ def fill_template(
 ) -> Path:
     """Fill ``template_path`` with values from ``worksheet_path``.
 
-    The processed document is saved to ``output_path``. If none is provided a
-    timestamped file is created next to the template.
+    Args:
+        template_path: Path to the template Word document.
+        worksheet_path: Path to the worksheet with answers.
+        output_path: Where to save the filled document. If ``None`` a
+            timestamped file is created beside ``template_path``.
+        schema: Optional placeholder mapping loaded from JSON or YAML.
+
+    Returns:
+        Path to the saved document.
+
+    Example:
+        >>> fill_template("template.docx", "worksheet.docx")
+        PosixPath('template_20250101_120000.docx')
     """
 
     template = Path(template_path)

--- a/src/scdocbuilder/api.py
+++ b/src/scdocbuilder/api.py
@@ -23,6 +23,7 @@ app.mount("/files", StaticFiles(directory=str(OUTPUT_DIR)), name="files")
 
 @app.get("/", response_class=HTMLResponse)  # type: ignore[misc]
 def index() -> HTMLResponse:
+    """Serve a simple upload form."""
     return HTMLResponse(
         """
         <html lang='en'>
@@ -42,6 +43,15 @@ def index() -> HTMLResponse:
 
 @app.post("/web-generate", response_class=HTMLResponse)  # type: ignore[misc]
 async def web_generate(template: UploadFile, worksheet: UploadFile) -> HTMLResponse:
+    """Process files uploaded via the HTML form.
+
+    Args:
+        template: DOCX template file.
+        worksheet: DOCX worksheet file.
+
+    Returns:
+        HTML page with a download link for the generated document.
+    """
     template_path = OUTPUT_DIR / f"{uuid4().hex}_template.docx"
     worksheet_path = OUTPUT_DIR / f"{uuid4().hex}_worksheet.docx"
     template_path.write_bytes(await template.read())
@@ -58,6 +68,16 @@ async def web_generate(template: UploadFile, worksheet: UploadFile) -> HTMLRespo
 async def generate(
     template: UploadFile, worksheet: UploadFile, html: bool = False
 ) -> HTMLResponse | FileResponse:
+    """Generate DOCX or HTML from uploaded files.
+
+    Args:
+        template: DOCX template file.
+        worksheet: DOCX worksheet file.
+        html: When ``True`` return sanitized HTML instead of DOCX.
+
+    Returns:
+        FileResponse with DOCX or HTMLResponse.
+    """
     template_path = OUTPUT_DIR / f"{uuid4().hex}_template.docx"
     worksheet_path = OUTPUT_DIR / f"{uuid4().hex}_worksheet.docx"
     template_path.write_bytes(await template.read())
@@ -76,4 +96,5 @@ async def generate(
 
 @app.get("/health")  # type: ignore[misc]
 def health() -> dict[str, str]:
+    """Return service status."""
     return {"status": "ok"}

--- a/src/scdocbuilder/benchmark.py
+++ b/src/scdocbuilder/benchmark.py
@@ -7,7 +7,15 @@ from time import perf_counter
 
 
 def benchmark_processing(template: Path, worksheet: Path) -> float:
-    """Return time in seconds to fill template using ``worksheet``."""
+    """Return time in seconds to process a worksheet.
+
+    Args:
+        template: Path to the template file.
+        worksheet: Path to the worksheet file.
+
+    Returns:
+        Time in seconds for loading both files.
+    """
     from .io import load_document
 
     start = perf_counter()

--- a/src/scdocbuilder/cli.py
+++ b/src/scdocbuilder/cli.py
@@ -27,7 +27,14 @@ class ErrorCode(IntEnum):
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    """Parse command-line arguments."""
+    """Parse command-line arguments.
+
+    Args:
+        argv: Argument list or ``None`` to read from ``sys.argv``.
+
+    Returns:
+        Parsed arguments namespace.
+    """
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--template", required=True, help="Path to template .docx")
@@ -55,7 +62,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> None:
-    """Run the placeholder replacer from the command line."""
+    """Run the placeholder replacer from the command line.
+
+    Args:
+        argv: Argument list or ``None`` to read from ``sys.argv``.
+
+    Raises:
+        SystemExit: With codes from :class:`ErrorCode` on failure.
+    """
 
     args = parse_args(argv)
     handlers: list[logging.Handler] = [

--- a/src/scdocbuilder/config.py
+++ b/src/scdocbuilder/config.py
@@ -10,7 +10,19 @@ from functools import lru_cache
 
 @lru_cache(maxsize=None)
 def load_placeholder_schema(path: Path) -> Dict[str, str]:
-    """Load placeholder schema from a JSON or YAML file."""
+    """Load placeholder schema from a JSON or YAML file.
+
+    Args:
+        path: File containing placeholder mappings.
+
+    Returns:
+        Dictionary mapping worksheet fields to template placeholders.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+        ImportError: If a YAML file is requested without ``PyYAML``.
+        ValueError: If the file extension is unsupported.
+    """
 
     if not path.exists():
         raise FileNotFoundError(str(path))

--- a/src/scdocbuilder/html_export.py
+++ b/src/scdocbuilder/html_export.py
@@ -7,7 +7,19 @@ from html import escape
 
 
 def export_html(doc: Document) -> str:
-    """Convert ``doc`` to sanitized HTML string."""
+    """Convert ``doc`` to sanitized HTML.
+
+    Args:
+        doc: Document to convert.
+
+    Returns:
+        HTML string safe for embedding in editors like TipTap.
+
+    Example:
+        >>> html = export_html(doc)
+        >>> html.startswith("<html>")
+        True
+    """
 
     parts = ["<html><body>"]
     for paragraph in doc.paragraphs:

--- a/src/scdocbuilder/io.py
+++ b/src/scdocbuilder/io.py
@@ -11,7 +11,16 @@ MAX_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
 def validate_input_files(template: Path, worksheet: Path) -> None:
-    """Validate that the provided files exist, are DOCX files and <10MB."""
+    """Validate that ``template`` and ``worksheet`` are DOCX files.
+
+    Args:
+        template: Path to the template document.
+        worksheet: Path to the worksheet document.
+
+    Raises:
+        FileNotFoundError: If any file is missing.
+        ValueError: If a file is not ``.docx`` or exceeds ``MAX_SIZE`` bytes.
+    """
 
     for file in (template, worksheet):
         if not file.exists():
@@ -23,14 +32,29 @@ def validate_input_files(template: Path, worksheet: Path) -> None:
 
 
 def load_document(path: Path) -> Any:
-    """Load a Word document from ``path`` using ``python-docx``."""
+    """Load a Word document from ``path``.
+
+    Args:
+        path: Location of the ``.docx`` file.
+
+    Returns:
+        ``python-docx`` document instance.
+    """
 
     validate_input_files(path, path)  # same file for both params to reuse checks
     return Document(str(path))
 
 
 def save_document(doc: Any, path: Path) -> None:
-    """Persist ``doc`` to ``path``."""
+    """Persist ``doc`` to ``path``.
+
+    Args:
+        doc: Document to write.
+        path: Destination filename ending with ``.docx``.
+
+    Raises:
+        ValueError: If ``path`` does not end with ``.docx``.
+    """
 
     if path.suffix.lower() != ".docx":
         raise ValueError("Output path must be .docx")

--- a/src/scdocbuilder/processing.py
+++ b/src/scdocbuilder/processing.py
@@ -24,7 +24,14 @@ OPTION_PATTERN = re.compile(r"\[\[OPTION_(\d)\]\](.*?)\[\[/OPTION_\1\]\]", re.DO
 
 
 def _iter_textbox_paragraphs(part: Any) -> list[Paragraph]:
-    """Return paragraphs contained in text boxes of ``part``."""
+    """Return paragraphs contained in text boxes of ``part``.
+
+    Args:
+        part: Document part whose text boxes are searched.
+
+    Returns:
+        List of paragraphs inside any text boxes.
+    """
     paragraphs: list[Paragraph] = []
     for txbx in part.element.xpath(".//w:txbxContent"):
         for p in txbx.xpath(".//w:p"):
@@ -33,7 +40,12 @@ def _iter_textbox_paragraphs(part: Any) -> list[Paragraph]:
 
 
 def _set_paragraph_text(paragraph: Paragraph, text: str) -> None:
-    """Replace paragraph runs with a single run containing ``text``."""
+    """Replace all runs in ``paragraph`` with ``text``.
+
+    Args:
+        paragraph: Paragraph to modify.
+        text: New content for the paragraph.
+    """
 
     for run in list(paragraph.runs):
         paragraph._p.remove(run._r)
@@ -46,7 +58,16 @@ def extract_fields(
 ) -> Dict[str, str]:
     """Extract placeholder values from a worksheet document.
 
-    ``field_mappings`` allows loading custom schemas from configuration files.
+    Args:
+        doc: Worksheet document to parse.
+        field_mappings: Optional mapping of question text to placeholders.
+
+    Returns:
+        Mapping of placeholders to user‑provided values.
+
+    Example:
+        >>> extract_fields(doc, {"Name:": "{Name}"})
+        {'{Name}': 'Alice'}
     """
 
     if field_mappings is None:
@@ -90,7 +111,12 @@ def extract_fields(
 
 
 def replace_placeholders(doc: Document, values: Dict[str, str]) -> None:
-    """Replace all placeholders in ``doc`` with provided values."""
+    """Replace all placeholders in ``doc`` with ``values``.
+
+    Args:
+        doc: Template document whose placeholders are replaced.
+        values: Mapping of placeholders to replacement text.
+    """
 
     def process_paragraph(paragraph: Any) -> None:
         for run in paragraph.runs:
@@ -123,7 +149,12 @@ def replace_placeholders(doc: Document, values: Dict[str, str]) -> None:
 
 
 def apply_conditionals(doc: Document, answers: Dict[str, str]) -> None:
-    """Remove conditional blocks that do not match the provided option."""
+    """Remove conditional blocks not matching the chosen option.
+
+    Args:
+        doc: Template document to modify.
+        answers: Mapping containing ``{Action option}``.
+    """
 
     active = answers.get("{Action option}")
     if not active:

--- a/src/scdocbuilder/security.py
+++ b/src/scdocbuilder/security.py
@@ -8,7 +8,15 @@ MACRO_PATTERNS = [b"vbaProject", b"macros"]
 
 
 def reject_macros(path: Path) -> None:
-    """Raise an error if ``path`` contains macros."""
+    """Raise ``ValueError`` if ``path`` contains macros.
+
+    Args:
+        path: Uploaded document to inspect.
+
+    Raises:
+        ValueError: If macros are detected.
+        FileNotFoundError: If ``path`` does not exist.
+    """
     if path.suffix.lower() == ".docm":
         raise ValueError("Macro-enabled documents are not allowed")
     try:
@@ -22,7 +30,11 @@ def reject_macros(path: Path) -> None:
 
 
 def cleanup_uploads(*paths: Path) -> None:
-    """Delete uploaded files."""
+    """Delete uploaded files.
+
+    Args:
+        *paths: Files to remove.
+    """
     for p in paths:
         try:
             p.unlink()

--- a/src/scdocbuilder/validation.py
+++ b/src/scdocbuilder/validation.py
@@ -23,7 +23,14 @@ def _find_question_answer(paragraphs: list[str], index: int) -> str:
 
 
 def validate_mandatory_fields(doc: Document) -> None:
-    """Raise ``ValueError`` if required worksheet fields are missing."""
+    """Check worksheet for required fields and questions.
+
+    Args:
+        doc: Worksheet document to validate.
+
+    Raises:
+        ValueError: If any mandatory field or question is missing.
+    """
 
     values = extract_fields(doc)
     for key in MANDATORY_PLACEHOLDERS:


### PR DESCRIPTION
## Summary
- clarify project purpose and quick start in README
- add scenarios and Python API reference docs
- document public functions with Google-style docstrings

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101` *(fails: command not found)*
- `pip install bandit` *(fails: 403 Forbidden)*
- `semgrep --config p/ci` *(fails: command not found)*
- `pip install semgrep` *(fails: 403 Forbidden)*
- `pytest -q --cov=src --cov-branch --cov-fail-under=70` *(fails: plugin missing)*
- `pip install pytest-cov` *(fails: 403 Forbidden)*
- `pytest -q` *(fails: _Document.__init__() takes 1 positional argument but 2 were given)*
- `pytest -q -m property`
- `pytest -q -m e2e`
- `mutmut run` *(fails: command not found)*
- `pip install mutmut` *(fails: 403 Forbidden)*
- `mkdocs build` *(fails: command not found)*
- `pip install mkdocs` *(fails: 403 Forbidden)*

ready-for:reviewer

------
https://chatgpt.com/codex/tasks/task_e_68946fe3d7bc833295473f722dce889e