### PR TITLE
Add Dockerfile and container packaging tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir .
+
+EXPOSE 8000
+
+ENTRYPOINT ["scdocbuilder"]

--- a/README.md
+++ b/README.md
@@ -118,6 +118,31 @@ npm run dev  # open http://localhost:5173
 
 ______________________________________________________________________
 
+## 🚢 Docker image
+
+Build and publish a containerised version of the CLI and API.
+
+```bash
+# Build the image
+docker build -t scdocbuilder .
+
+# Use the CLI
+docker run --rm scdocbuilder --help
+
+# Run the API on port 8000
+docker run --rm -p 8000:8000 scdocbuilder api serve --host 0.0.0.0
+
+# Push to a registry (example uses GitHub Container Registry)
+docker tag scdocbuilder ghcr.io/<user>/scdocbuilder:latest
+docker push ghcr.io/<user>/scdocbuilder:latest
+
+# Alternatively use the helper script
+./scripts/docker-build.sh                # build only
+./scripts/docker-build.sh scdocbuilder ghcr.io/<user>   # build and push
+```
+
+______________________________________________________________________
+
 ## 🧪 Quality Checks & Testing Guide
 
 This project uses a multi-tool testing pipeline to ensure code quality, formatting, type safety, security, and robustness. Below is the full suite of commands and best practices for local development and CI validation.

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="${1:-scdocbuilder}"
+REGISTRY="${2:-}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+docker build -t "$IMAGE_NAME" "$REPO_ROOT"
+
+if [ -n "$REGISTRY" ]; then
+  docker tag "$IMAGE_NAME" "$REGISTRY/$IMAGE_NAME"
+  docker push "$REGISTRY/$IMAGE_NAME"
+fi

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -14,9 +14,15 @@ def test_console_script_entrypoint() -> None:
 
 
 @pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
-@pytest.mark.xfail(reason="Docker image not yet provided")
 def test_docker_image_help() -> None:
     """`docker run scdocbuilder --help` should print usage information."""
+    build = subprocess.run(
+        ["docker", "build", "-t", "scdocbuilder", "."],
+        capture_output=True,
+        text=True,
+    )
+    assert build.returncode == 0, build.stderr
+
     result = subprocess.run(
         ["docker", "run", "--rm", "scdocbuilder", "--help"],
         capture_output=True,


### PR DESCRIPTION
## Summary
- add Dockerfile exposing scdocbuilder CLI and API port
- document building and pushing container images
- verify docker `scdocbuilder --help` in tests

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101`
- `semgrep --config p/ci` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q --cov=src --cov-branch --cov-fail-under=70` *(interrupted after completion)*
- `pytest -q -m property`
- `pytest -q -m e2e`
- `mutmut run` *(fails: tests/test_cli.py::test_cli_exits_zero_with_required_args)*

------
https://chatgpt.com/codex/tasks/task_e_689f7f99c2988332a284e6016a28a58a