### PR TITLE
Fix Pyright issues and add FastAPI dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6,11 +6,31 @@ version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
 ]
+
+[[package]]
+name = "anyio"
+version = "4.10.0"
+description = "High-level concurrency and networking framework on top of asyncio or Trio"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1"},
+    {file = "anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6"},
+]
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
+
+[package.extras]
+trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "attrs"
@@ -101,6 +121,24 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.10)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "bleach"
+version = "6.2.0"
+description = "An easy safelist-based HTML-sanitizing tool."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "bleach-6.2.0-py3-none-any.whl", hash = "sha256:117d9c6097a7c3d22fd578fcd8d35ff1e125df6736f554da4e432fdd63f31e5e"},
+    {file = "bleach-6.2.0.tar.gz", hash = "sha256:123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f"},
+]
+
+[package.dependencies]
+webencodings = "*"
+
+[package.extras]
+css = ["tinycss2 (>=1.1.0,<1.5)"]
 
 [[package]]
 name = "boltons"
@@ -289,6 +327,18 @@ test = ["pytest"]
 test-cov = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "cobble"
+version = "0.1.4"
+description = "Create data objects"
+optional = false
+python-versions = ">=3.5"
+groups = ["main"]
+files = [
+    {file = "cobble-0.1.4-py3-none-any.whl", hash = "sha256:36c91b1655e599fd428e2b95fdd5f0da1ca2e9f1abb0bc871dec21a0e78a2b44"},
+    {file = "cobble-0.1.4.tar.gz", hash = "sha256:de38be1539992c8a06e569630717c485a5f91be2192c461ea2b220607dfa78aa"},
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -451,6 +501,28 @@ files = [
 
 [package.dependencies]
 boltons = ">=20.0.0"
+
+[[package]]
+name = "fastapi"
+version = "0.116.1"
+description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "fastapi-0.116.1-py3-none-any.whl", hash = "sha256:c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565"},
+    {file = "fastapi-0.116.1.tar.gz", hash = "sha256:ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143"},
+]
+
+[package.dependencies]
+pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
+starlette = ">=0.40.0,<0.48.0"
+typing-extensions = ">=4.8.0"
+
+[package.extras]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
 name = "filelock"
@@ -630,7 +702,7 @@ version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -817,6 +889,21 @@ cssselect = ["cssselect (>=0.7)"]
 html-clean = ["lxml_html_clean"]
 html5 = ["html5lib"]
 htmlsoup = ["BeautifulSoup4"]
+
+[[package]]
+name = "mammoth"
+version = "1.10.0"
+description = "Convert Word documents from docx to simple and clean HTML and Markdown"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "mammoth-1.10.0-py2.py3-none-any.whl", hash = "sha256:a1c87d5b98ca30230394267f98614b58b14b50f8031dc33ac9a535c6ab04eb99"},
+    {file = "mammoth-1.10.0.tar.gz", hash = "sha256:cb6fbba41ccf8b5502859c457177d87a833fef0e0b1d4e6fd23ec372fe892c30"},
+]
+
+[package.dependencies]
+cobble = ">=0.1.3,<0.2"
 
 [[package]]
 name = "markdown-it-py"
@@ -1233,7 +1320,7 @@ version = "2.8.2"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pydantic-2.8.2-py3-none-any.whl", hash = "sha256:73ee9fddd406dc318b885c7a2eab8a6472b68b8fb5ba8150949fc3db939f23c8"},
     {file = "pydantic-2.8.2.tar.gz", hash = "sha256:6f62c13d067b0755ad1c21a34bdd06c0c12625a22b0fc09c6b149816604f7c2a"},
@@ -1256,7 +1343,7 @@ version = "2.20.1"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pydantic_core-2.20.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3acae97ffd19bf091c72df4d726d552c473f3576409b2a7ca36b2f535ffff4a3"},
     {file = "pydantic_core-2.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41f4c96227a67a013e7de5ff8f20fb496ce573893b7f4f2707d065907bffdbd6"},
@@ -1456,6 +1543,18 @@ files = [
 [package.dependencies]
 lxml = ">=3.1.0"
 typing_extensions = ">=4.9.0"
+
+[[package]]
+name = "python-magic"
+version = "0.4.27"
+description = "File type identification using libmagic"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+groups = ["main"]
+files = [
+    {file = "python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b"},
+    {file = "python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3"},
+]
 
 [[package]]
 name = "pyyaml"
@@ -1909,6 +2008,18 @@ files = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -1919,6 +2030,25 @@ files = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
+
+[[package]]
+name = "starlette"
+version = "0.47.2"
+description = "The little ASGI library that shines."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "starlette-0.47.2-py3-none-any.whl", hash = "sha256:c5847e96134e5c5371ee9fac6fdf1a67336d5815e09eb2a01fdb57a351ef915b"},
+    {file = "starlette-0.47.2.tar.gz", hash = "sha256:6ae9aa5db235e4846decc1e7b79c4f346adf41e9777aebeb49dfd09bbd7023d8"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""}
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "stevedore"
@@ -2012,6 +2142,18 @@ files = [
 
 [package.dependencies]
 bracex = ">=2.1.1"
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+description = "Character encoding aliases for legacy web content"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
+    {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
+]
 
 [[package]]
 name = "wrapt"
@@ -2125,4 +2267,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "d43fb42b6e3a4128765688ff17f416fc9c5ec66c8527669fcb30119644111df8"
+content-hash = "2980d4eb4eae402fec06873eef9ecc14b8a041822eab23e04da1d7deca46e0e0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ rich = "^13.7"
 mammoth = "^1.6"
 bleach = "^6.1"
 python-magic = "^0.4"
+fastapi = "^0.116.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ rich>=13.7
 mammoth>=1.6
 bleach>=6.1
 python-magic>=0.4
+fastapi>=0.116.1

--- a/tests/property/test_benchmark_prop.py
+++ b/tests/property/test_benchmark_prop.py
@@ -1,30 +1,26 @@
-from typing import Any, Callable, TypeVar, cast, no_type_check
-import typing
+from typing import Any, Callable, TYPE_CHECKING, cast, no_type_check
 from pathlib import Path
 
 import pytest
 from tests.property.strategies import docx_path
 from scdocbuilder.benchmark import benchmark_processing
 
-if typing.TYPE_CHECKING:
+Decorator = Callable[[Callable[..., Any]], Callable[..., Any]]
+
+if TYPE_CHECKING:
     from docx import Document
+    from hypothesis import HealthCheck, given as given_decorator, settings
+
+    def property_mark(func: Callable[..., Any]) -> Callable[..., Any]: ...
 else:
     pytest.importorskip("docx")
     from docx import Document
 
-F = TypeVar("F", bound=Callable[..., Any])
-
-if typing.TYPE_CHECKING:
-    from hypothesis import given as given_decorator
-    from hypothesis import settings, HealthCheck
-
-    property_mark: Callable[[F], F]
-else:
     hypothesis = pytest.importorskip("hypothesis")
-    given_decorator = cast(Callable[[F], F], hypothesis.given)
+    given_decorator = cast(Decorator, hypothesis.given)
     settings = hypothesis.settings
     HealthCheck = hypothesis.HealthCheck
-    property_mark = cast(Callable[[F], F], pytest.mark.property)
+    property_mark = cast(Decorator, pytest.mark.property)
 
 
 @no_type_check

--- a/tests/property/test_html_export_prop.py
+++ b/tests/property/test_html_export_prop.py
@@ -1,9 +1,8 @@
-from typing import Any, Callable, TypeVar, cast, no_type_check
-import typing
+from typing import Any, Callable, TYPE_CHECKING, cast, no_type_check
 
 import pytest
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from docx import Document
 else:
     pytest.importorskip("docx")
@@ -11,26 +10,25 @@ else:
 
 from scdocbuilder.html_export import export_html
 
-F = TypeVar("F", bound=Callable[..., Any])
+Decorator = Callable[[Callable[..., Any]], Callable[..., Any]]
 
-if typing.TYPE_CHECKING:
-    from hypothesis import given as given_decorator
+if TYPE_CHECKING:
+    from hypothesis import HealthCheck, given as given_decorator, settings
     from hypothesis import strategies as st
-    from hypothesis import settings, HealthCheck
 
-    property_mark: Callable[[F], F]
+    def property_mark(func: Callable[..., Any]) -> Callable[..., Any]: ...
 else:
     hypothesis = pytest.importorskip("hypothesis")
-    given_decorator = cast(Callable[[F], F], hypothesis.given)
+    given_decorator = cast(Decorator, hypothesis.given)
     st = hypothesis.strategies
     settings = hypothesis.settings
     HealthCheck = hypothesis.HealthCheck
-    property_mark = cast(Callable[[F], F], pytest.mark.property)
+    property_mark = cast(Decorator, pytest.mark.property)
 
 
 @no_type_check
 @property_mark
-@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,), deadline=None)
 @given_decorator(
     text=st.text(alphabet=st.characters(min_codepoint=32, max_codepoint=126))
 )

--- a/tests/property/test_io_properties.py
+++ b/tests/property/test_io_properties.py
@@ -1,28 +1,26 @@
-import typing
-from typing import Any, Callable, TypeVar, cast, no_type_check
+from typing import Any, Callable, TYPE_CHECKING, cast, no_type_check
 from pathlib import Path
 import pytest
 
-if not typing.TYPE_CHECKING:
+if not TYPE_CHECKING:
     pytest.importorskip("docx")
 
 from docx import Document
 from scdocbuilder.io import validate_input_files
 from tests.property.strategies import docx_path
 
-F = TypeVar("F", bound=Callable[..., Any])
+Decorator = Callable[[Callable[..., Any]], Callable[..., Any]]
 
-if typing.TYPE_CHECKING:
-    from hypothesis import given as given_decorator
-    from hypothesis import settings, HealthCheck
+if TYPE_CHECKING:
+    from hypothesis import HealthCheck, given as given_decorator, settings
 
-    property_mark: Callable[[F], F]
+    def property_mark(func: Callable[..., Any]) -> Callable[..., Any]: ...
 else:
     hypothesis = pytest.importorskip("hypothesis")
-    given_decorator = cast(Callable[[F], F], hypothesis.given)
+    given_decorator = cast(Decorator, hypothesis.given)
     settings = hypothesis.settings
     HealthCheck = hypothesis.HealthCheck
-    property_mark = cast(Callable[[F], F], pytest.mark.property)
+    property_mark = cast(Decorator, pytest.mark.property)
 
 
 @no_type_check

--- a/tests/property/test_security_prop.py
+++ b/tests/property/test_security_prop.py
@@ -1,26 +1,24 @@
-from typing import Any, Callable, TypeVar, cast, no_type_check
-import typing
+from typing import Any, Callable, TYPE_CHECKING, cast, no_type_check
 from pathlib import Path
 
 import pytest
 from tests.property.strategies import docx_path
 from scdocbuilder.security import reject_macros, cleanup_uploads
 
-F = TypeVar("F", bound=Callable[..., Any])
+Decorator = Callable[[Callable[..., Any]], Callable[..., Any]]
 
-if typing.TYPE_CHECKING:
-    from hypothesis import given as given_decorator
+if TYPE_CHECKING:
+    from hypothesis import HealthCheck, given as given_decorator, settings
     from hypothesis import strategies as st
-    from hypothesis import settings, HealthCheck
 
-    property_mark: Callable[[F], F]
+    def property_mark(func: Callable[..., Any]) -> Callable[..., Any]: ...
 else:
     hypothesis = pytest.importorskip("hypothesis")
-    given_decorator = cast(Callable[[F], F], hypothesis.given)
+    given_decorator = cast(Decorator, hypothesis.given)
     st = hypothesis.strategies
     settings = hypothesis.settings
     HealthCheck = hypothesis.HealthCheck
-    property_mark = cast(Callable[[F], F], pytest.mark.property)
+    property_mark = cast(Decorator, pytest.mark.property)
 
 
 @no_type_check

--- a/tests/unit/test_html_export.py
+++ b/tests/unit/test_html_export.py
@@ -2,7 +2,7 @@ import typing
 from typing import Any, Mapping
 import pytest
 import builtins
-import importlib
+import importlib.util
 
 if typing.TYPE_CHECKING:
     from docx import Document


### PR DESCRIPTION
## Summary
- include FastAPI as a dependency
- refactor property tests to avoid TypeVar errors and define stubs for optional marks
- adjust importlib usage in HTML export test

## Testing
- `pyright`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a11d416cb0833285e023115ea1b9fc