### PR TITLE
Handle invalid inputs and directories

### DIFF
--- a/src/scdocbuilder/config.py
+++ b/src/scdocbuilder/config.py
@@ -22,7 +22,10 @@ def _parse_simple_yaml(text: str) -> Dict[str, str]:
             continue
         if ":" in line:
             key, value = line.split(":", 1)
+            key = key.strip()
             value = value.strip()
+            if not key:
+                raise ValueError("Empty key in YAML mapping")
 
             quoted = bool(value and value[0] in {'"', "'"})
             # Remove inline comments for unquoted values.  YAML only treats "#"
@@ -72,7 +75,7 @@ def _parse_simple_yaml(text: str) -> Dict[str, str]:
                 if stack:
                     raise ValueError("Unbalanced brackets in YAML value")
 
-            result[key.strip()] = value
+            result[key] = value
         else:
             # Any non-comment, non-empty line without a colon indicates the file
             # is not a simple key/value mapping.  Reject it to mirror YAML's

--- a/src/scdocbuilder/io.py
+++ b/src/scdocbuilder/io.py
@@ -24,7 +24,7 @@ def validate_input_files(template: Path, worksheet: Path) -> None:
     """
 
     for file in (template, worksheet):
-        if not file.exists():
+        if not file.exists() or not file.is_file():
             raise FileNotFoundError(str(file))
         if file.suffix.lower() != ".docx":
             raise ValueError(f"{file} is not a .docx file")

--- a/src/scdocbuilder/security.py
+++ b/src/scdocbuilder/security.py
@@ -17,7 +17,7 @@ def reject_macros(path: Path) -> None:
         ValueError: If macros are detected.
         FileNotFoundError: If ``path`` does not exist.
     """
-    if not path.exists():
+    if not path.exists() or not path.is_file():
         raise FileNotFoundError(str(path))
     if path.suffix.lower() in {".docm", ".dotm"}:
         raise ValueError("Macro-enabled documents are not allowed")

--- a/tests/test_config_extra.py
+++ b/tests/test_config_extra.py
@@ -105,6 +105,11 @@ def test_parse_simple_yaml_empty_value() -> None:
     assert config._parse_simple_yaml("A:") == {"A": ""}
 
 
+def test_parse_simple_yaml_rejects_empty_keys() -> None:
+    with pytest.raises(ValueError):
+        config._parse_simple_yaml(": value")
+
+
 def test_load_placeholder_schema_yaml_fallback(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -49,7 +49,8 @@ def test_validate_input_files_magic_error(tmp_path: Path, monkeypatch: pytest.Mo
     Document().save(str(t))
     Document().save(str(w))
 
-    import types, sys
+    import sys
+    import types
 
     def fake_from_buffer(*args: Any, **kwargs: Any) -> str:
         raise OSError("missing magic database")

--- a/tests/test_io_extra.py
+++ b/tests/test_io_extra.py
@@ -26,3 +26,11 @@ def test_validate_input_files_rejects_wrong_mime(tmp_path: Path) -> None:
     bogus.write_text("not a real docx")
     with pytest.raises(ValueError):
         validate_input_files(bogus, bogus)
+
+
+def test_validate_input_files_rejects_directories(tmp_path: Path) -> None:
+    """Directories masquerading as files should be rejected."""
+    directory = tmp_path / "dir.docx"
+    directory.mkdir()
+    with pytest.raises(FileNotFoundError):
+        validate_input_files(directory, directory)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -45,6 +45,14 @@ def test_reject_macros_missing_file(tmp_path: Path) -> None:
         reject_macros(path)
 
 
+def test_reject_macros_rejects_directory(tmp_path: Path) -> None:
+    """Directories should be treated like missing files."""
+    directory = tmp_path / "dir.docx"
+    directory.mkdir()
+    with pytest.raises(FileNotFoundError):
+        reject_macros(directory)
+
+
 def test_reject_macros_scans_entire_file(tmp_path: Path) -> None:
     """Macro signatures after the initial chunk should still be detected."""
     path = tmp_path / "late.docx"


### PR DESCRIPTION
## Summary
- ensure directories masquerading as .docx files are rejected consistently
- treat directory uploads as missing files for macro scanning
- prevent parsing of empty keys in fallback YAML parser
- tidy import order to satisfy ruff

## Testing
- `ruff check .`
- `pytest --maxfail=1 --disable-warnings --cov=. --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_68c73e2b13a88332806b077ce2c38010